### PR TITLE
Dockerfile and example docker-compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,117 @@
+# Build all the bins
+FROM golang:buster AS builder
+
+ENV APP     /go/src/Dominator
+ENV COMMIT  ee0024f8ccc1ce647137e1c75dc68f40e19c0ed2
+
+RUN git clone https://github.com/Cloud-Foundations/Dominator.git $APP \
+    && cd $APP \
+    && git checkout $COMMIT
+
+WORKDIR $APP
+
+RUN go get -d -v ./...
+RUN CGO_ENABLED=0 make
+
+# Imaginator Server
+FROM debianlive/base:latest AS imaginator
+
+EXPOSE 6975
+
+VOLUME /var/log/imaginator
+
+RUN apt-get update \
+    && apt-get -y install debootstrap git
+
+COPY --from=builder /go/bin/imaginator /bin/imaginator
+
+ENTRYPOINT ["/bin/imaginator"]
+
+# Dominator Server
+FROM debianlive/base:latest AS dominator
+
+EXPOSE 6970
+
+RUN useradd -rm -d /home/dominator -s /bin/bash -u 1000 dominator \
+    && mkdir -p /var/lib/Dominator \
+       /var/lib/mdbd \
+       /var/log/dominator \
+    && chown -R dominator:dominator /var/lib/Dominator \
+       /var/lib/mdbd \
+       /var/log/dominator
+
+VOLUME /var/lib/Dominator
+VOLUME /var/lib/mdbd
+VOLUME /var/log/dominator
+
+COPY --from=builder /go/bin/dominator /bin/dominator
+COPY --from=builder /go/bin/domtool /bin/domtool
+
+USER dominator
+
+ENTRYPOINT ["/bin/dominator"]
+
+# Image Server
+FROM debianlive/base:latest AS imageserver
+
+EXPOSE 6971
+
+RUN useradd -rm -d /home/imageserver -s /bin/bash -u 1000 imageserver \
+    && mkdir -p /var/lib/objectserver \
+       /var/lib/imageserver \
+       /var/log/imageserver \
+    && chown -R imageserver:imageserver /var/lib/objectserver \
+       /var/lib/imageserver \
+       /var/log/imageserver
+
+VOLUME /var/log/imageserver
+VOLUME /var/lib/imageserver
+VOLUME /var/lib/objectserver
+
+COPY --from=builder /go/bin/imageserver /bin/imageserver
+
+USER imageserver
+
+ENTRYPOINT ["/bin/imageserver"]
+
+# MDBD Server
+FROM debianlive/base:latest AS mdbd
+
+EXPOSE 6973
+
+# /var/lib/mdbd/mdb.sources.list must be volumed into the container
+RUN useradd -rm -d /home/mdbd -s /bin/bash -u 1000 mdbd \
+    && mkdir -p /var/lib/mdbd \
+       /var/log/mdbd \
+    && chown -R mdbd:mdbd /var/lib/mdbd \
+       /var/log/mdbd
+
+VOLUME /var/log/mdbd
+VOLUME /var/lib/mdbd
+
+COPY mdbd/mdbd /bin/mdbd
+
+USER mdbd
+
+ENTRYPOINT ["/bin/mdbd"]
+
+# Filegen Server
+FROM debianlive/base:latest AS filegenserver
+
+EXPOSE 6972
+
+# /var/lib/mdbd/mdb.sources.list must be volumed into the container
+RUN useradd -rm -d /home/fg -s /bin/bash -u 1000 fg \
+    && mkdir -p /var/lib/filegenserver \
+       /var/log/filegenserver \
+    && chown -R fg:fg /var/lib/filegenserver \
+       /var/log/filegenserver
+
+VOLUME /var/log/filegenserver
+VOLUME /var/lib/filegenserver
+
+COPY filegenserver/filegenserver /bin/filegenserver
+
+USER fg
+
+ENTRYPOINT ["/bin/filegenserver"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN go get -d -v ./...
 RUN CGO_ENABLED=0 make
 
 # Imaginator Server
-FROM debianlive/base:latest AS imaginator
+FROM debian:buster-backports AS imaginator
 
 EXPOSE 6975
 
@@ -28,7 +28,7 @@ COPY --from=builder /go/bin/imaginator /bin/imaginator
 ENTRYPOINT ["/bin/imaginator"]
 
 # Dominator Server
-FROM debianlive/base:latest AS dominator
+FROM debian:buster-backports AS dominator
 
 EXPOSE 6970
 
@@ -52,7 +52,7 @@ USER dominator
 ENTRYPOINT ["/bin/dominator"]
 
 # Image Server
-FROM debianlive/base:latest AS imageserver
+FROM debian:buster-backports AS imageserver
 
 EXPOSE 6971
 
@@ -75,7 +75,7 @@ USER imageserver
 ENTRYPOINT ["/bin/imageserver"]
 
 # MDBD Server
-FROM debianlive/base:latest AS mdbd
+FROM debian:buster-backports AS mdbd
 
 EXPOSE 6973
 
@@ -96,7 +96,7 @@ USER mdbd
 ENTRYPOINT ["/bin/mdbd"]
 
 # Filegen Server
-FROM debianlive/base:latest AS filegenserver
+FROM debian:buster-backports AS filegenserver
 
 EXPOSE 6972
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,86 @@
+version: "3.3"
+services:
+
+  dominator:
+    image: dominator
+    expose:
+      - 6970
+    ports:
+      - 6970:6970
+    environment:
+      HOST_IP: $HOST_IP
+      MDB_FILE: $MDB_FILE # /var/lib/mdbd/mdb.json
+    volumes: 
+      - ./volume/log/dominator:/var/log/dominator
+      - ./mdbd:/var/lib/mdbd:ro
+      - ./certs/CA.pem:/etc/ssl/CA.pem
+      - ./certs/dominator:/etc/ssl/dominator/
+      - ./certs/cli/:/home/dominator/.ssl/
+    depends_on:
+      - mdbd
+      - imageserver
+    command: -alsoLogToStderr -debug -useIP -mdbFile $MDB_FILE -imageServerHostname $HOST_IP
+
+  mdbd:
+    image: mdbd
+    expose:
+      - 6973
+    ports:
+      - 6973:6973
+    volumes: 
+      - ./secrets/collins.yaml:/etc/collins.yaml:ro
+      - ./mdbd:/var/lib/mdbd
+      - ./volume/log/mdbd:/var/log/mdbd
+      - ./certs/CA.pem:/etc/ssl/CA.pem
+      - ./certs/mdbd/:/etc/ssl/mdbd/
+    command: -alsoLogToStderr -debug
+
+  imageserver:
+    image: imageserver
+    expose:
+      - 6971
+    ports:
+      - 6971:6971
+    volumes: 
+      - ./volume/log/imageserver:/var/log/imageserver
+      - ./volume/imageserver:/var/lib/imageserver
+      - ./volume/objectserver:/var/lib/objectserver
+      - ./certs/CA.pem:/etc/ssl/CA.pem
+      - ./certs/imageserver/:/etc/ssl/imageserver/
+    command: -alsoLogToStderr -debug
+
+  imaginator:
+    image: imaginator
+    expose:
+      - 6975
+    ports:
+      - 6975:6975
+    environment:
+      HOST_IP: $HOST_IP
+      SSH_AUTH_SOCK: $SSH_AUTH_SOCK
+    volumes:
+      - ./volume/imaginator/tmp:/tmp
+      - $SSH_AUTH_SOCK:$SSH_AUTH_SOCK
+      - ./imaginator:/etc/imaginator
+      - ./volume/log/imaginator:/var/log/imaginator
+      - ./certs/CA.pem:/etc/ssl/CA.pem
+      - ./certs/imaginator/:/etc/ssl/imaginator/
+    privileged: true
+    depends_on:
+      - imageserver
+    command: -alsoLogToStderr -imageRebuildInterval 24h -imageServerHostname $HOST_IP
+
+  filegenerator:
+    image: filegenserver
+    expose:
+      - 6972
+    ports:
+      - 6972:6972
+    volumes:
+      - ./filegenserver:/var/lib/filegenserver
+      - ./filegenserver/gens:/gens
+      - ./volume/log/filegenserver:/var/log/filegenserver
+      - ./certs/CA.pem:/etc/ssl/CA.pem
+      - ./certs/filegen-server/:/etc/ssl/filegenserver/
+    command: -alsoLogToStderr
+

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
     ports:
       - 6973:6973
     volumes: 
-      - ./secrets/collins.yaml:/etc/collins.yaml:ro
       - ./mdbd:/var/lib/mdbd
       - ./volume/log/mdbd:/var/log/mdbd
       - ./certs/CA.pem:/etc/ssl/CA.pem


### PR DESCRIPTION
This is a Dockerfile that builds all services needed to run dominator on-prem. I also added an example docker-compose file. To get it working you would need to do a little bit of work to generate your certs as well as configure filegen and mdbd for your needs.